### PR TITLE
Regular Expresions

### DIFF
--- a/src/com/megadevs/tcpsourceapp/TCPSourceApp.java
+++ b/src/com/megadevs/tcpsourceapp/TCPSourceApp.java
@@ -120,8 +120,8 @@ public class TCPSourceApp {
 	 * 	- port
 	 * 	- PID
 	 */
-	private static final String TCP_6_PATTERN 	= "\\d:\\s([0-9A-F]{32}):([0-9A-F]{4})\\s[0-9A-F]{32}:[0-9A-F]{4}\\s[0-9A-F]{2}\\s[0-9]{8}:[0-9]{8}\\s[0-9]{2}:[0-9]{8}\\s[0-9]{8}\\s([0-9]+)";
-	private static final String TCP_4_PATTERN 	= "\\d:\\s([0-9A-F]{8}):([0-9A-F]{4})\\s[0-9A-F]{8}:[0-9A-F]{4}\\s[0-9A-F]{2}\\s[0-9A-F]{8}:[0-9A-F]{8}\\s[0-9]{2}:[0-9]{8}\\s[0-9A-F]{8}\\s\\s([0-9]+)";
+	private static final String TCP_6_PATTERN 	= "\\d+:\\s([0-9A-F]{32}):([0-9A-F]{4})\\s[0-9A-F]{32}:[0-9A-F]{4}\\s[0-9A-F]{2}\\s[0-9]{8}:[0-9]{8}\\s[0-9]{2}:[0-9]{8}\\s[0-9]{8}\\s+([0-9]+)";
+	private static final String TCP_4_PATTERN 	= "\\d+:\\s([0-9A-F]{8}):([0-9A-F]{4})\\s[0-9A-F]{8}:[0-9A-F]{4}\\s[0-9A-F]{2}\\s[0-9A-F]{8}:[0-9A-F]{8}\\s[0-9]{2}:[0-9]{8}\\s[0-9A-F]{8}\\s+([0-9]+)";
 
 	/*
 	 * Optimises the socket lookup by checking if the connected network 


### PR DESCRIPTION
regular expresions for proc/net/tcp and proc/net/tcp6 files fixed. The problem was that only the first 10 entries in both files were matched because the regex starts with \\d instead of \\d+. Besides in the file  proc/net/tcp only the entries with uid of length 4 were matched due to the space regex \\s\\s instead of \\s+.